### PR TITLE
Add readme reference to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Krypt is swiss-army knife for encoding, decoding, encryption, dec
 homepage = "https://github.com/Stupremee/krypt"
 documentation = "https://docs.rs/krypt"
 repository = "https://github.com/Stupremee/krypt"
+readme = "README.md"
 
 [lib]
 name = "krypt"


### PR DESCRIPTION
This way crates.io can render the readme on the page for the crate